### PR TITLE
Fixed the BufferedSumoLogicAppender timing. It used to ignore the max…

### DIFF
--- a/src/main/java/com/sumologic/log4j/aggregation/BufferFlushingTask.java
+++ b/src/main/java/com/sumologic/log4j/aggregation/BufferFlushingTask.java
@@ -26,10 +26,10 @@
 package com.sumologic.log4j.aggregation;
 
 import com.sumologic.log4j.queue.BufferWithEviction;
+
 import org.apache.log4j.helpers.LogLog;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 /**
@@ -61,6 +61,7 @@ public abstract class BufferFlushingTask<In, Out> implements Runnable {
                     messageQueue.size()));
             Out body = aggregate(messages);
             sendOut(body, getName());
+            timeOfLastFlush = System.currentTimeMillis();
         }
     }
 


### PR DESCRIPTION
…FlushInterval setting and just send every 250ms. Now it requires either the queue to become full or the maxFlushInterval to pass before it sends the next batch. This fixes #23.