### PR TITLE
Add sourceName/Category/Host metadata support for log4j appender

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The library can be added to your project using Maven Central by adding the follo
 <dependency>
     <groupId>com.sumologic.plugins.log4j</groupId>
     <artifactId>sumo-log4j-appender</artifactId>
-    <version>2.4</version>
+    <version>2.5</version>
 </dependency>
 ```
 
@@ -34,8 +34,14 @@ Be sure to replace the `url` field with the URL after creating an HTTP Hosted Co
     # Direct log messages to sumo
     log4j.appender.sumo=com.sumologic.log4j.SumoLogicAppender
     log4j.appender.sumo.layout=org.apache.log4j.PatternLayout
-    log4j.appender.sumo.layout.ConversionPattern=%d{DATE} %5p %c{1}:%L - %m%n
+    log4j.appender.sumo.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS Z} [%t] %-5p %c - %m%n
     log4j.appender.sumo.url=<YOUR_URL_HERE>
+
+    # Optional parameters for Metadata
+    log4j.appender.sumo.sourceName=<YOUR SOURCE NAME>
+    log4j.appender.sumo.sourceHost=<YOUR SOURCE HOST>
+    log4j.appender.sumo.sourceCategory=<YOUR SOURCE CATEGORY>
+
     # Optional parameters for Proxy servers
     log4j.appender.sumo.proxyAuth=<YOUR AUTHTYPE: basic or ntlm>
     log4j.appender.sumo.proxyHost=<YOUR HOSTNAME>
@@ -50,6 +56,9 @@ Be sure to replace the `url` field with the URL after creating an HTTP Hosted Co
 | Parameter          | Required? | Default Value | Description                                                                                                                                |
 |--------------------|----------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------|
 | url                | Yes      |               | HTTP collection endpoint URL                                                                                                               |
+| sourceName         | No       | "Http Input"              | Source name to appear when searching on Sumo Logic by `_sourceName`
+| sourceHost         | No       | Client IP Address              | Source host to appear when searching on Sumo Logic by `sourceHost`
+| sourceCategory     | No       | "Http Input"              | Source category to appear when searching on Sumo Logic by _`sourceCategory`
 | proxyHost          | No       |               | Proxy host IP address                                                                                                                      |
 | proxyPort          | No       |               | Proxy host port number                                                                                                                     |
 | proxyAuth          | No       |               | For basic authentication proxy, set to "basic". For NTLM authentication proxy, set to "ntlm". For no authentication proxy, do not specify. |

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sumologic.plugins.log4j</groupId>
     <artifactId>sumo-log4j-appender</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.5-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Sumo Logic Log4J Appender</name>
     <description>The Log4J Appender for the Sumo Logic log management service</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sumologic.plugins.log4j</groupId>
     <artifactId>sumo-log4j-appender</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.5</version>
     <packaging>jar</packaging>
     <name>Sumo Logic Log4J Appender</name>
     <description>The Log4J Appender for the Sumo Logic log management service</description>

--- a/src/main/java/com/sumologic/log4j/SumoLogicAppender.java
+++ b/src/main/java/com/sumologic/log4j/SumoLogicAppender.java
@@ -59,7 +59,10 @@ public class SumoLogicAppender extends AppenderSkeleton {
     private long messagesPerRequest = 100;    // How many messages need to be in the queue before we flush
     private long maxFlushInterval = 10000;    // Maximum interval between flushes (ms)
     private long flushingAccuracy = 250;      // How often the flushed thread looks into the message queue (ms)
-    private String sourceName = "Log4J-SumoObject"; // Name to stamp for querying with _sourceName
+
+    private String sourceName = null;
+    private String sourceHost = null;
+    private String sourceCategory = null;
 
     private long maxQueueSizeBytes = 1000000;
 
@@ -88,6 +91,14 @@ public class SumoLogicAppender extends AppenderSkeleton {
 
     public void setSourceName(String sourceName) {
         this.sourceName = sourceName;
+    }
+
+    public void setSourceHost(String sourceHost) {
+        this.sourceHost = sourceHost;
+    }
+
+    public void setSourceCategory(String sourceCategory) {
+        this.sourceCategory = sourceCategory;
     }
 
     public void setFlushingAccuracy(long flushingAccuracy) {
@@ -180,6 +191,9 @@ public class SumoLogicAppender extends AppenderSkeleton {
         sender.setConnectionTimeout(connectionTimeout);
         sender.setSocketTimeout(socketTimeout);
         sender.setUrl(url);
+        sender.setSourceHost(sourceHost);
+        sender.setSourceName(sourceName);
+        sender.setSourceCategory(sourceCategory);
         sender.setProxySettings(new ProxySettings(
                 proxyHost,
                 proxyPort,
@@ -197,7 +211,6 @@ public class SumoLogicAppender extends AppenderSkeleton {
         flusher = new SumoBufferFlusher(flushingAccuracy,
                 messagesPerRequest,
                 maxFlushInterval,
-                sourceName,
                 sender,
                 queue);
         flusher.start();

--- a/src/main/java/com/sumologic/log4j/aggregation/BufferFlushingTask.java
+++ b/src/main/java/com/sumologic/log4j/aggregation/BufferFlushingTask.java
@@ -60,7 +60,7 @@ public abstract class BufferFlushingTask<In, Out> implements Runnable {
                     messages.size(),
                     messageQueue.size()));
             Out body = aggregate(messages);
-            sendOut(body, getName());
+            sendOut(body);
             timeOfLastFlush = System.currentTimeMillis();
         }
     }
@@ -70,7 +70,6 @@ public abstract class BufferFlushingTask<In, Out> implements Runnable {
 
     abstract protected long getMaxFlushInterval();
     abstract protected long getMessagesPerRequest();
-    abstract protected String getName();
 
     protected BufferFlushingTask(BufferWithEviction<In> messageQueue) {
         this.messageQueue = messageQueue;
@@ -79,7 +78,7 @@ public abstract class BufferFlushingTask<In, Out> implements Runnable {
     // Given the list of messages, aggregate them into a single Out object
     abstract protected Out aggregate(List<In> messages);
     // Send aggregated message out. Block until we've successfully sent it.
-    abstract protected void sendOut(Out body, String name);
+    abstract protected void sendOut(Out body);
 
 
 

--- a/src/main/java/com/sumologic/log4j/aggregation/SumoBufferFlusher.java
+++ b/src/main/java/com/sumologic/log4j/aggregation/SumoBufferFlusher.java
@@ -45,7 +45,6 @@ public class SumoBufferFlusher {
             long flushingAccuracy,
             long messagesPerRequest,
             long maxFlushInterval,
-            String sourceName,
             SumoHttpSender sender,
             BufferWithEviction<String> buffer) {
 
@@ -55,7 +54,6 @@ public class SumoBufferFlusher {
 
         flushingTask.setMessagesPerRequest(messagesPerRequest);
         flushingTask.setMaxFlushInterval(maxFlushInterval);
-        flushingTask.setName(sourceName);
         flushingTask.setSender(sender);
     }
 

--- a/src/main/java/com/sumologic/log4j/http/SumoBufferFlushingTask.java
+++ b/src/main/java/com/sumologic/log4j/http/SumoBufferFlushingTask.java
@@ -39,14 +39,9 @@ public class SumoBufferFlushingTask extends BufferFlushingTask<String, String> {
     private SumoHttpSender sender;
     private long maxFlushInterval;
     private long messagesPerRequest;
-    private String name;
 
     public SumoBufferFlushingTask(BufferWithEviction<String> queue) {
         super(queue);
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     public void setSender(SumoHttpSender sender) {
@@ -72,11 +67,6 @@ public class SumoBufferFlushingTask extends BufferFlushingTask<String, String> {
     }
 
     @Override
-    protected String getName() {
-        return name;
-    }
-
-    @Override
     protected String aggregate(List<String> messages) {
         StringBuilder builder = new StringBuilder(messages.size() * 10);
         for (String message: messages) {
@@ -86,9 +76,9 @@ public class SumoBufferFlushingTask extends BufferFlushingTask<String, String> {
     }
 
     @Override
-    protected void sendOut(String body, String name) {
+    protected void sendOut(String body) {
         if (sender != null && sender.isInitialized()) {
-            sender.send(body, name);
+            sender.send(body);
         } else {
             LogLog.error("HTTPSender is not initialized");
         }

--- a/src/test/java/com/sumologic/log4j/aggregation/BufferFlushingTaskTest.java
+++ b/src/test/java/com/sumologic/log4j/aggregation/BufferFlushingTaskTest.java
@@ -132,17 +132,12 @@ public class BufferFlushingTaskTest {
             }
 
             @Override
-            protected String getName() {
-                return "No-name";
-            }
-
-            @Override
             protected List<String> aggregate(List<String> messages) {
                 return messages;
             }
 
             @Override
-            protected void sendOut(List<String> body, String name) {
+            protected void sendOut(List<String> body) {
                 tasks.add(body);
             }
         };


### PR DESCRIPTION
This PR refactors existing support for `sourceName` metadata, and adds additional metadata fields for `sourceCategory` and `sourceHost` based on https://help.sumologic.com/Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source/Upload-Data-to-an-HTTP-Source#Other_Supported_HTTP_Headers.