### PR TITLE
Add retryableHttpCodeRegex for configurable HTTP retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Alternatively you can use XML configuration to configure the Sumo Logic Log4j ap
 | proxyPassword      | No       |               | Proxy host password for basic and NTLM authentication. For no authentication proxy, do not specify.                                        |
 | proxyDomain        | No       |               | Proxy host domain name for NTLM authentication only
 | flushAllBeforeStopping        | No       | false              | Flush all messages before stopping regardless of flushingAccuracy. Be sure to call `LogManager.shutdown();` when your application stops.
+| retryableHttpCodeRegex| No       | ^5.*         | Regular expression specifying which HTTP error code(s) should be retried during sending. By default, all 5xx error codes will be retried.
 
 ## TLS 1.2 Requirement
 

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.sumologic.plugins.http</groupId>
             <artifactId>sumologic-http-core</artifactId>
-            <version>1.1</version>
+            <version>1.4</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/sumologic/log4j/SumoLogicAppender.java
+++ b/src/main/java/com/sumologic/log4j/SumoLogicAppender.java
@@ -67,6 +67,8 @@ public class SumoLogicAppender extends AppenderSkeleton {
 
     private long maxQueueSizeBytes = 1000000;
 
+    private String retryableHttpCodeRegex = "^5.*";
+
     private SumoHttpSender sender;
     private SumoBufferFlusher flusher;
     volatile private BufferWithEviction<String> queue;
@@ -192,6 +194,14 @@ public class SumoLogicAppender extends AppenderSkeleton {
         return flushAllBeforeStopping;
     }
 
+    public void setRetryableHttpCodeRegex(String retryableHttpCodeRegex) {
+        this.retryableHttpCodeRegex = retryableHttpCodeRegex;
+    }
+
+    public String getRetryableHttpCodeRegex() {
+        return retryableHttpCodeRegex;
+    }
+
     public void setFlushAllBeforeStopping(boolean flushAllBeforeStopping) {
         this.flushAllBeforeStopping = flushAllBeforeStopping;
     }
@@ -218,9 +228,9 @@ public class SumoLogicAppender extends AppenderSkeleton {
         if (sender == null)
             sender = new SumoHttpSender();
 
-        sender.setRetryInterval(retryInterval);
-        sender.setConnectionTimeout(connectionTimeout);
-        sender.setSocketTimeout(socketTimeout);
+        sender.setRetryIntervalMs(retryInterval);
+        sender.setConnectionTimeoutMs(connectionTimeout);
+        sender.setSocketTimeoutMs(socketTimeout);
         sender.setUrl(url);
         sender.setSourceHost(sourceHost);
         sender.setSourceName(sourceName);
@@ -233,6 +243,7 @@ public class SumoLogicAppender extends AppenderSkeleton {
                 proxyPassword,
                 proxyDomain));
         sender.setClientHeaderValue(CLIENT_NAME);
+        sender.setRetryableHttpCodeRegex(retryableHttpCodeRegex);
         sender.init();
 
         /* Initialize flusher  */


### PR DESCRIPTION
Adds a parameter for `retryableHttpCodeRegex` that is configurable with a regex string.  By default we have it match `^5.*` for all 5xx, but the user can override it however they want with a regular expression.

Based on https://github.com/SumoLogic/sumologic-java-http-core/pull/8